### PR TITLE
Actualizar Spring Boot a versión 3.3.0 y dependencias relacionadas

### DIFF
--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -23,28 +23,28 @@
         module pom file -->
         <project.rootdir>${project.basedir}/..</project.rootdir>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring.boot.version>2.1.0.RELEASE</spring.boot.version>
-        <findbugs.annotations.version>2.0.1</findbugs.annotations.version>
-        <nimbus.jose.jwt.version>4.39.2</nimbus.jose.jwt.version>
-        <mockito.core.version>2.8.9</mockito.core.version>
-        <azuremonitor.micrometer.registry.version>1.1.0</azuremonitor.micrometer.registry.version>
-        <micrometer.core.version>1.1.0</micrometer.core.version>
-        <spring-boot-actuator-autoconfigure.version>2.1.0.RELEASE</spring-boot-actuator-autoconfigure.version>
-        <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
-        <wiremock-standalone.version>2.19.0</wiremock-standalone.version>
-        <commons-io.version>2.3</commons-io.version>
-        <hibernate.validator.version>6.0.9.Final</hibernate.validator.version>
+        <spring.boot.version>3.3.0</spring.boot.version>
+        <findbugs.annotations.version>3.1.12</findbugs.annotations.version>
+        <nimbus.jose.jwt.version>9.37.3</nimbus.jose.jwt.version>
+        <mockito.core.version>5.7.0</mockito.core.version>
+        <azuremonitor.micrometer.registry.version>1.3.2</azuremonitor.micrometer.registry.version>
+        <micrometer.core.version>1.13.0</micrometer.core.version>
+        <spring-boot-actuator-autoconfigure.version>3.3.0</spring-boot-actuator-autoconfigure.version>
+        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
+        <wiremock-standalone.version>3.5.0</wiremock-standalone.version>
+        <commons-io.version>2.15.1</commons-io.version>
+        <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
     </properties>
 
     <profiles>
         <profile>
-            <id>doclint-java8-disable</id>
+            <id>doclint-java17-disable</id>
             <activation>
-                <jdk>[1.8,)</jdk>
+                <jdk>[17,)</jdk>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
- Actualizar Spring Boot de 2.1.0.RELEASE a 3.3.0
- Actualizar Java source/target de 1.8 a 17 (requerido para Spring Boot 3.x)
- Actualizar versiones de dependencias compatibles con Spring Boot 3.3.0:
  - Mockito: 5.7.0
  - Nimbus JOSE JWT: 9.37.3
  - Micrometer: 1.13.0
  - Hibernate Validator: 8.0.1.Final
  - WireMock: 3.5.0
  - Commons IO: 2.15.1
  - FindBugs: 3.1.12
  - Maven Javadoc Plugin: 3.6.3
- Actualizar perfil de Java de 8 a 17

https://claude.ai/code/session_019JvvqcySbPknk7FXFAHhs6