### PR TITLE
docs: remove Travis CI and AppVeyor badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Travis CI](https://travis-ci.org/Microsoft/azure-spring-boot.svg?branch=master)](https://travis-ci.org/Microsoft/azure-spring-boot)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/af0qeprdv3g9ox07/branch/master?svg=true)](https://ci.appveyor.com/project/yungez/azure-spring-boot)
 [![codecov](https://codecov.io/gh/Microsoft/azure-spring-boot/branch/master/graph/badge.svg)](https://codecov.io/gh/Microsoft/azure-spring-boot)
 [![MIT License](http://img.shields.io/badge/license-MIT-green.svg) ](https://github.com/Microsoft/azure-spring-boot/blob/master/LICENSE)
 [![Gitter](https://badges.gitter.im/Microsoft/spring-on-azure.svg)](https://gitter.im/Microsoft/spring-on-azure)


### PR DESCRIPTION
## Summary

Remove the Travis CI and AppVeyor CI badges from the top of the README. Both services are no longer in use for this project.

Remaining badges: codecov, MIT License, Gitter.

## Test plan

- [ ] README renders correctly without the removed badges on the GitHub repository home page

---
_Generated by [Claude Code](https://claude.ai/code/session_019JvvqcySbPknk7FXFAHhs6)_