### PR TITLE
chore: add devcontainer and GitHub Actions CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+  "name": "Azure Spring Boot",
+  "image": "mcr.microsoft.com/devcontainers/java:1-21-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "21",
+      "installMaven": true,
+      "mavenVersion": "3.9"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "vscjava.vscode-spring-initializr",
+        "vscjava.vscode-spring-boot-dashboard",
+        "vmware.vscode-spring-boot",
+        "redhat.vscode-xml",
+        "sonarsource.sonarlint-vscode",
+        "github.vscode-pull-request-github"
+      ],
+      "settings": {
+        "java.jdt.ls.java.home": "/usr/lib/jvm/msopenjdk-current",
+        "java.compile.nullAnalysis.mode": "automatic",
+        "spring-boot.ls.java.home": "/usr/lib/jvm/msopenjdk-current",
+        "editor.formatOnSave": true,
+        "java.checkstyle.configuration": "${workspaceFolder}/config/checkstyle.xml"
+      }
+    }
+  },
+  "postCreateCommand": "mvn dependency:resolve -q || true",
+  "postStartCommand": "echo '✅ Dev container ready. Run: mvn clean verify'",
+  "remoteEnv": {
+    "MAVEN_OPTS": "-Xmx2g -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.m2,target=/root/.m2,type=bind,consistency=cached"
+  ],
+  "forwardPorts": [8080, 8443],
+  "portsAttributes": {
+    "8080": { "label": "Spring Boot App", "onAutoForward": "notify" }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  build-and-test:
+    name: Build & Test (Java ${{ matrix.java }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [17, 21]
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: microsoft
+          cache: maven
+
+      - name: Build & Unit Tests
+        run: mvn clean verify --no-transfer-progress -Dgpg.skip=true
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-java${{ matrix.java }}
+          path: '**/target/surefire-reports/*.xml'
+          retention-days: 7
+
+  spotbugs:
+    name: SpotBugs Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: microsoft
+          cache: maven
+
+      - name: Run SpotBugs
+        run: mvn compile spotbugs:check --no-transfer-progress -pl azure-spring-boot -Dgpg.skip=true
+
+      - name: Upload SpotBugs report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spotbugs-report
+          path: azure-spring-boot/target/spotbugsXml.xml
+          retention-days: 7
+
+  build-samples:
+    name: Build Samples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: microsoft
+          cache: maven
+
+      - name: Build parent & BOM first
+        run: mvn install -DskipTests --no-transfer-progress -Dgpg.skip=true -pl . -pl azure-spring-boot-bom -pl azure-spring-boot-parent -pl azure-spring-boot -am
+
+      - name: Build samples
+        run: mvn package -DskipTests --no-transfer-progress -Dgpg.skip=true -pl azure-spring-boot-samples -am


### PR DESCRIPTION
## Summary

Adds development infrastructure for testing the Spring Cloud Azure 4.20.0 migration:

### Dev Container (`.devcontainer/devcontainer.json`)
- **Image**: `mcr.microsoft.com/devcontainers/java:1-21-bullseye` (Java 21)
- **Features**: Maven 3.9, GitHub CLI
- **VS Code extensions**: Java Pack, Spring Boot Dashboard, Spring Boot Tools, XML, SonarLint
- **Maven local cache** mounted from host to speed up dependency resolution
- **Port 8080** auto-forwarded for running samples locally
- `postCreateCommand`: pre-resolves dependencies on container start

### GitHub Actions CI (`.github/workflows/ci.yml`)

Three parallel jobs triggered on push/PR to `master`:

| Job | What it does |
|---|---|
| `build-and-test` | Matrix build on Java 17 & 21 — `mvn clean verify` including unit tests |
| `spotbugs` | Static analysis — `mvn spotbugs:check` on `azure-spring-boot` module |
| `build-samples` | Compiles all sample projects to catch regressions |

Test reports and SpotBugs XML uploaded as artifacts on every run.

## Test plan
- [ ] Open repo in GitHub Codespaces / VS Code Dev Containers — container builds without errors
- [ ] `mvn clean verify` runs successfully inside the container
- [ ] CI workflow triggers on this PR and all three jobs pass

---
_Generated by [Claude Code](https://claude.ai/code/session_019JvvqcySbPknk7FXFAHhs6)_